### PR TITLE
DPAC-202 - improve network error handling for timelogging

### DIFF
--- a/src/scripts/assess/controllers/TimelogsController.js
+++ b/src/scripts/assess/controllers/TimelogsController.js
@@ -11,7 +11,7 @@ module.exports = Controller.extend( {
     contextEvents: {
         'comparisons:editing:requested': 'verifyTimelogState',
         'comparisons:editing:completed': 'stopLogging',
-        'assess:pause:requested': 'stopLogging',
+        'comparison:stop:requested': 'stopLogging',
         'assess:resume:requested': 'verifyTimelogState'
     },
 

--- a/src/scripts/assess/models/TimelogProxy.js
+++ b/src/scripts/assess/models/TimelogProxy.js
@@ -1,5 +1,5 @@
 'use strict';
-const {Model} = require( 'backbone' );
+const { Model } = require( 'backbone' );
 const moment = require( 'moment' );
 const debug = require( 'debug' )( 'dpac:assess', '[TimelogProxy]' );
 const teardown = require( '../../common/mixins/teardown' );
@@ -23,7 +23,7 @@ module.exports = Model.extend( {
         this.set( 'end', now );
 
         this.save();
-        this.intervalId = setInterval( this.update.bind( this ), this.get( 'updateInterval' ) );
+        this.startPolling();
     },
 
     parse: function( raw ){
@@ -40,10 +40,30 @@ module.exports = Model.extend( {
         return this;
     },
 
+    startPolling: function(){
+        debug( `Start polling server every ${this.get( 'updateInterval' ) / 1000} seconds ` );
+        this.intervalId = setInterval( this.update.bind( this ), this.get( 'updateInterval' ) );
+    },
+
+    stopPolling: function(){
+        clearInterval( this.intervalId );
+        this.intervalId = undefined;
+    },
+
     stop: function(){
         this.update();
-        clearInterval(this.intervalId);
-        this.intervalId = undefined;
+        this.stopPolling();
+    },
+
+    save: function( attrs = null,
+                    options = {} ){
+        options.disableErrorPropagation = true;
+        options.error = ( err ) =>{
+            this.stopPolling();
+            this.set( 'updateInterval', this.get( 'updateInterval' ) + 3000 ); //lower polling frequency for low latency networks
+            this.startPolling();
+        };
+        Model.prototype.save.call( this, attrs, options );
     }
 } );
 teardown.model.mixin( module.exports );

--- a/src/scripts/core/controllers/ConfigureApplication.js
+++ b/src/scripts/core/controllers/ConfigureApplication.js
@@ -18,7 +18,7 @@ extend( module.exports.prototype, {
                 "root": process.env.API_HOST + "api"
             },
             "timelogs": {
-                "interval": 5000,
+                "interval": 10000,
                 "shortcut": "ctrl+alt+s"
             },
             "errorlogs": {

--- a/src/scripts/core/controllers/SetupRemoteRequests.js
+++ b/src/scripts/core/controllers/SetupRemoteRequests.js
@@ -89,7 +89,9 @@ extend(SetupRemoteRequests.prototype, {
                     };
                 }
                 console.log("REMOTE REQUEST ERROR", errObj);
-                dispatch("backbone:sync:error", errObj);
+                if(!options.disableErrorPropagation){
+                    dispatch("backbone:sync:error", errObj);
+                }
                 errorCallback(...args);
             };
 


### PR DESCRIPTION
* raise the default polling interval

And, when network errors occur while time logging:

* hide network errors
* raise the polling interval