### PR TITLE
ATZ-16 #fix bower registry

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,4 @@
 {
-    "directory": "bower_components"
+    "directory": "bower_components",
+    "registry": "https://registry.bower.io"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ RUN apk upgrade libssl1.0 --update-cache \
 ADD package.json /tmp/package.json
 RUN cd /tmp && npm install
 
+ADD .bowerrc /tmp/.bowerrc
 ADD bower.json /tmp/bower.json
-RUN cd /tmp && ./node_modules/.bin/bower install --allow-root
+RUN cd /tmp && ./node_modules/.bin/bower install --allow-root --quiet
 
 RUN mkdir -p /home/dpac && mv /tmp/node_modules /home/dpac/ && mv /tmp/bower_components /home/dpac
 RUN mv /tmp/package.json /home/dpac/package.json && mv /tmp/bower.json /home/dpac/bower.json


### PR DESCRIPTION
The bower registry on heroku was deprecated, we need to point bower to the correct one: https://gist.github.com/sheerun/c04d856a7a368bad2896ff0c4958cb00